### PR TITLE
The last point of a line should be added with the same drawID as the …

### DIFF
--- a/public/js/whiteboard.js
+++ b/public/js/whiteboard.js
@@ -180,7 +180,9 @@ var whiteboard = {
                 _this.sendFunction({ "t": _this.tool, "d": [currX, currY, _this.startCoords[0], _this.startCoords[1]], "c": _this.drawcolor, "th": _this.thickness });
                 _this.svgContainer.find("line").remove();
             } else if (_this.tool === "pen") {
+		_this.drawId--;
                 _this.pushPointSmoothPen(currX, currY);
+		_this.drawId++;
             } else if (_this.tool === "rect") {
                 if (_this.pressedKeys.shift) {
                     if ((currY - _this.startCoords[1]) * (currX - _this.startCoords[0]) > 0) {


### PR DESCRIPTION
…rest of the line.

A bug was introduced in my last PR. Due to the change of the pen behavior (for smooth line), the last part of the drawing was added in the mouseover method, but after the increment of drawId. This introduce the need of two `undo` for undoing a track, which is annoying.

This PR fix this bug.