### PR TITLE
Make whiteboard deployable to Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "webpack --config config/webpack.build.js",
     "start:dev": "node scripts/server.js --mode=development",
-    "start:prod": "npm run build && node scripts/server.js --mode=production",
+    "start:prod": "npm run build && npm run start",
+    "start": "node scripts/server.js --mode=production",
     "test": "jest",
     "pretty-quick": "pretty-quick",
     "format": "prettier --write .",

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -28,5 +28,5 @@ if (server_mode === SERVER_MODES.DEVELOPMENT) {
     startBackendServer(3000);
 } else {
     console.info("Starting server in production mode.");
-    startBackendServer(8080);
+    startBackendServer(process.env.PORT || 8080);
 }


### PR DESCRIPTION
As mentioned in #18 the whiteboard previously crashed when deployed to Heroku. I fixed it.

Since Heroku looks for `npm start` I had to provide that command. 