### PR TITLE
Fix duplicate content drawing on window resize

### DIFF
--- a/src/js/whiteboard.js
+++ b/src/js/whiteboard.js
@@ -118,12 +118,9 @@ const whiteboard = {
         this.oldGCO = this.ctx.globalCompositeOperation;
 
         window.addEventListener("resize", function () {
-            // Handel resize
-            const dbCp = JSON.parse(JSON.stringify(_this.drawBuffer)); // Copy the buffer
             _this.canvas.width = $(window).width();
             _this.canvas.height = $(window).height(); // Set new canvas height
             _this.drawBuffer = [];
-            _this.loadData(dbCp); // draw old content in
         });
 
         $(_this.mouseOverlay).on("mousedown touchstart", function (e) {


### PR DESCRIPTION
Using Brave browser.

When a window with Whiteboard gets resized, in whiteboard.js an event listener for "resize" kicks in. It is meant to clear the canvas and then redraw Whiteboard content. It works OK, but text boxes, which are in a separate DIV do not get cleared.
So a new set of duplicate text boxes gets added on top of the existing ones.
It also has impact on text filling. If content gets duplicated, text box IDs also get duplicated and text can be put in a text box in a lower layer, resulting in top layer text box not being rendered correctly.
Before resize
![before_resize](https://user-images.githubusercontent.com/2900734/118951178-2b9ffd80-b95b-11eb-9cee-4e8f3f66cca5.png)
After resize
![after_resize](https://user-images.githubusercontent.com/2900734/118951202-3195de80-b95b-11eb-8264-20e871435110.png)

The patch I as suggesting is a simple emptying text boxes DIV. Seems to work OK.