### PR TITLE
Prevent btoa() error if username contains non-Lating characters

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -154,7 +154,7 @@ function initWhiteboard() {
         whiteboard.loadWhiteboard("#whiteboardContainer", {
             //Load the whiteboard
             whiteboardId: whiteboardId,
-            username: btoa(myUsername),
+            username: btoa(encodeURIComponent(myUsername)),
             backgroundGridUrl: "./images/" + ConfigService.backgroundGridImage,
             sendFunction: function (content) {
                 if (ReadOnlyService.readOnlyActive) return;


### PR DESCRIPTION
If username parameter contains non-Latin characters, for example "Ἀγαθίνος", then btoa() throws an error. The value needs to encoded first. Decoding is already present in whiteboard.js line #1271