### PR TITLE
Security improvements: protect from directory traversal and iFrame content injection

### DIFF
--- a/scripts/s_whiteboard.js
+++ b/scripts/s_whiteboard.js
@@ -1,6 +1,8 @@
 //This file is only for saving the whiteboard.
 const fs = require("fs");
+const path = require("path");
 const config = require("./config/config");
+const FILE_DATABASE_FOLDER = "savedBoards";
 
 var savedBoards = {};
 var savedUndos = {};
@@ -144,7 +146,13 @@ module.exports = {
         // try to load from DB
         if (config.backend.enableFileDatabase) {
             //read saved board from file
-            var filePath = "savedBoards/" + wid + ".json";
+            var fileName = wid + ".json";
+            var filePath = FILE_DATABASE_FOLDER + "/" + fileName;
+            if(path.dirname(filePath) !== FILE_DATABASE_FOLDER || path.basename(fileName) !== fileName) {
+                var errorMessage = "Attempted path traversal attack: ";
+                console.log(errorMessage, filePath);
+                throw new Error(errorMessage + filePath);
+            }
             if (fs.existsSync(filePath)) {
                 var data = fs.readFileSync(filePath);
                 if (data) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -907,7 +907,7 @@ function initWhiteboard() {
 
     // handle pasting from clipboard
     window.addEventListener("paste", function (e) {
-        if ($(".basicalert").length > 0) {
+        if ($(".basicalert").length > 0 || !!e.origin) {
             return;
         }
         if (e.clipboardData) {


### PR DESCRIPTION
I've included two security related bug-fixes in this PR:

1. Improve protections from directory traversal when using file database option

Using `path.dirname`, we can get the path from the generated `filePath`. If `path.dirname` does not match `FILE_DATABASE_FOLDER`, then we know that the given `wid` contains path information and should not be trusted.

Example:

```javascript
var wid = '../../example';
var fileName = wid + ".json";
var filePath = FILE_DATABASE_FOLDER + "/" + fileName;
path.dirname(filePath); // "savedBoards/../.." != "savedBoards"
```

Using `path.basename`, we can get the filename from the generated `filePath`. If the `path.basename` does not match `fileName`, then we know that the given `wid` contains path information and should not be trusted.

Example:

```javascript
var wid = '../../example';
var fileName = wid + ".json";
var filePath = FILE_DATABASE_FOLDER + "/" + fileName;
path.basename(fileName); // "example.json" != "../../example.json"
```

2. Prevent iFrames/popups from injecting content into the whiteboard through fake 'paste' events

A malicious iframe or popup link could generate a false "paste" event using the `Window.postMessage` API. A false event would have `event.origin` set to be the iFrame's URL. Real `paste` events have an undefined `event.origin`. This PR ensure `event.origin` is unset before injecting the content into the Whiteboard. Read more here: https://sonarcloud.io/organizations/lightswitch05/rules?open=javascript%3AS2819&rule_key=javascript%3AS2819