### PR TITLE
docker-compose: define volumes to allow persistency of whiteboards

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,7 @@ services:
     ports:
       - "8080:8080/tcp"
     command: --config=./config.default.yml
+    volumes:
+    - ./data/uploads:/opt/app/public/uploads"
+    - ./data/config.yml:/opt/app/config.default.yml:ro
+    - ./data/savedBoards:/opt/app/savedBoards"


### PR DESCRIPTION
When destroying a container, all the data that was written to the
overlay file system is lost. This documents which paths must be mounted
to allow persisting data in docker volumes across restarts and removed
containers.