### PR TITLE
CI: switch to docker buildx and enable arm64 docker images

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -14,5 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag rofl256/whiteboard:$(date +%s)
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: build the image
+        run: |
+          docker buildx build \
+          --file Dockerfile \
+          --tag rofl256/whiteboard:$(date +%s) \
+          --platform linux/amd64,linux/arm64 .


### PR DESCRIPTION
Hi,

for modern cloud servers and single board computers (like the popular Raspberry Pi's) it would be really nice to have arm64 images available.

This PR switches the docker build process over to Dockers new buildx process, which handles multi-arch building of images automatically.

The images at Dockerhub (https://hub.docker.com/r/rofl256/whiteboard ) don't seem to be generated from GitHub Actions yet (probably manually generated?).

There is one downside to doing this: arm64 build is done using QEMU emulation, which is a bit slower.
An alternative way would be to use GitHub's native ARM64 runners for this, but it's more setup work.

I have tested this container on ARM64 and it seems to work very well:
![screenshot of whiteboard, saying hello from arm64](https://screenshot.tbspace.de/zbjdyinqgxm.png)

What do you think?